### PR TITLE
Add and document app-init helper script

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -38,7 +38,7 @@ $ gp -install YkOtpApplet.cap
 CAP loaded
 -----
 
-The easiest way to program the applet with an HMAC secret is to use
+If installed on a Yubikey, you can program the applet with an HMAC secret using
 https://github.com/arekinath/yktool[yktool]:
 
 -----
@@ -52,6 +52,26 @@ Programmed slot 1 ok
 $ printf 'aaaa' | yktool hmac 1 -x
 72:7E:C8:E8:15:EE:C5:32:8F:9D:9C:BE:5E:F2:4E:A8:36:D7:CE:56
 -----
+
+If you install the applet to another JavaCard without HID capabilities, that tool
+won't detect your card as a Yubikey. You can program a secret by sending the correct
+ADPU sequence to your card. A helper script to generate those ADPUs is included in
+the repository:
+
+-----
+$ cat /dev/random | ./show_initalization_command.py
+opensc-tool -s 00A4040007A000000527200100 -s 0001030034000000000000000000000000000000001B1AECF9000077C051BAFD8E996FEED70C1384BEB94E0000000000000000402600000000
+-----
+
+The script must be fed with exactly twenty bytes of keying material - the
+HMAC secret for the slot. If you have the secret in hex form you can use 
+`xxd -r -p` to convert it to binary.
+
+Sending these two ADPUs (one to select the correct applet and one to program
+a slot config) to the card will initialize the applet. You can send ADPUs with
+GlobalPlatformPro, OpenSC, or the JavaCard tool of your choice.
+
+See the contents of the Python script to set a slot protection ("access") code.
 
 ## Building the project
 

--- a/show_initalization_command.py
+++ b/show_initalization_command.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+
+import sys
+
+SLOT_ID = 2
+NEW_ACC = '000000000000' # Set this to what you want, but don't lose it. You'll need this to change a slot's configuration.
+OLD_ACC = ''
+APP_ID = 'A0000005272001' # Don't change this if you want Yubikey compatibility...
+
+if len(NEW_ACC) != 12:
+    print('Invalid new access code: should be 6 bytes')
+    sys.exit(1)
+
+if len(OLD_ACC) not in [0, 12]:
+    print('Invalid old access code: should be either six or zero bytes')
+    sys.exit(1)
+
+with open(0, 'rb') as f:
+    raw_key = f.read(20)
+
+if len(raw_key) < 20:
+    print('Failed to read 20 bytes of key material from standard input')
+    sys.exit(1)
+
+hex_key = raw_key.hex().upper()
+key = hex_key[:32] # 16 bytes of key first
+uid = hex_key[32:] + '0000' # ... and then four bytes of UID, padded out to a six-byte UID string
+
+assert len(key) == 32
+assert len(uid) == 12
+
+s = '00' * 16 # Fixed bytes, not used
+s += uid # Four bytes of the key, remaining two unused
+s += key # Sixteen bytes of key
+s += NEW_ACC # Access code
+s += '00' # Fixed byte, not used
+s += '00' # Extflags, not used
+s += '40' # Tktflags, contains magic setting for challenge-response mode
+s += '260000' # Cfgflags, contains magic settings for HMAC
+s += '00' * 2 # CRC, not used
+s += OLD_ACC # Access code previously set
+
+if len(s) != 104 + len(OLD_ACC):
+    print('Invalid overall ADPU length')
+    sys.exit(1)
+
+len_encoded = '34'
+if OLD_ACC != '':
+    len_encoded = '3A'
+
+slot_encoding = '01'
+if SLOT_ID == 2:
+    slot_encoding = '03'
+
+print('opensc-tool -s %s -s %s' % ('00A4040007' + APP_ID + '00', '0001' + slot_encoding + '00' + len_encoded + s))


### PR DESCRIPTION
I'm well aware this repository hasn't been updated in five years, and I can see a valid-looking PR already open to fix a bug, so I don't anticipate this PR will be merged. Nonetheless I hope this will help someone who uses the working code in this repository.

The applet here can generate HMAC challenge-response codes on a JavaCard that isn't a Yubikey. When you set it up that way, you need to get the "slot config" - the HMAC secret - into the applet somehow.

This pull request contains a simple Python script that will emit the correct ADPUs to program an arbitrary JavaCard with an HMAC secret of the user's choice. I had to learn ISO7816 to write this script; perhaps with it in hand, someone else can skip that journey of discovery and make easier use of their own smartcard.

Documentation for the use of the script is also included.